### PR TITLE
Add GUI smoke test workflow

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -2,13 +2,13 @@ name: 🧪 Test snap can be built
 
 on:
   push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
 
 jobs:
   build:
+    name: Build snap
     runs-on: ubuntu-latest
 
     steps:
@@ -36,3 +36,87 @@ jobs:
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}
+          retention-days: 7
+
+  smoke-test:
+    name: Smoke test (launch + screenshot)
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: snap
+          path: .
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Set up LXD
+        uses: canonical/setup-lxd@v0.1.1
+
+      - name: Install ghvmctl
+        run: |
+          sudo snap install ghvmctl --channel=stable
+          sudo snap connect ghvmctl:lxd lxd:lxd
+
+      - name: Prepare VM
+        run: ghvmctl prepare
+
+      - name: Install local snap in VM
+        run: |
+          set -eux
+          SNAP_FILE=$(find . -maxdepth 1 -name '*.snap' | head -n 1)
+          VM_NAME=$(ghvmctl exec -- hostname | tr -d '\n')
+          lxc file push "$SNAP_FILE" "local:${VM_NAME}/home/ubuntu/$(basename "$SNAP_FILE")"
+          ghvmctl exec -- sudo snap install --dangerous --classic "/home/ubuntu/$(basename "$SNAP_FILE")"
+
+      - name: Launch Notepad Next
+        run: |
+          ghvmctl snap-run notepadnext.notepadnext
+          sleep 30
+
+      - name: Capture screenshots
+        if: always()
+        run: |
+          ghvmctl screenshot-full
+          ghvmctl screenshot-window
+          ls -lh "$HOME/ghvmctl-screenshots/" || true
+
+      - name: Show app logs
+        if: always()
+        run: ghvmctl exec -- cat /home/ubuntu/notepadnext.notepadnext.log 2>/dev/null || true
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: smoke-test-screenshots
+          path: ~/ghvmctl-screenshots/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Comment on PR with screenshot link
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### Smoke test\n\nSnap launched in a VM. Screenshots are available as the \`smoke-test-screenshots\` artifact on the [run](${runUrl}).`
+            });


### PR DESCRIPTION
## Summary
- run the existing test workflow on branch pushes so fork validation works before opening a PR
- keep the existing snap build and review job for this classic snap
- add a dependent VM smoke-test job that installs the built snap with `--classic`, launches `notepadnext`, and uploads screenshots

## Validation
- passing fork workflow run: https://github.com/minnielove2026/notepadnext-snap/actions/runs/25035967734
- confirmed the smoke-test job completed through VM prep, classic install, app launch, screenshot capture, and artifact upload


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GUI smoke test to CI that installs the built classic snap in a VM, launches Notepad Next, and uploads screenshots. Also runs the build workflow on all branch pushes to validate forks before PRs.

- **New Features**
  - Run build on all branch pushes and PRs.
  - Add VM smoke test: set up LXD with `ghvmctl`, install snap with `--classic`, launch `notepadnext.notepadnext`, capture and upload `smoke-test-screenshots`.
  - Post a PR comment with a link to the run and screenshots.
  - Keep the snap artifact for 7 days.

- **Dependencies**
  - Add `canonical/setup-lxd@v0.1.1`, `actions/checkout@v4`, `actions/download-artifact@v4`, `actions/upload-artifact@v4`, `actions/github-script@v7`, and the `ghvmctl` snap.

<sup>Written for commit 591c1289f389a09d1895010e7a0fc8fe8ba42d31. Summary will update on new commits. <a href="https://cubic.dev/pr/popey/notepadnext-snap/pull/6?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

