### PR TITLE
Fix v0.14 snap build with CMake

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,17 +65,20 @@ parts:
         https://github.com/dail8859/NotepadNext.git
     override-build: |
       cd NotepadNext
-      qmake6 src/NotepadNext.pro "DISTRIBUTION=Snap"
-      make -j$(nproc)
-      make install INSTALL_ROOT=$SNAPCRAFT_PART_INSTALL
+      cmake -S . -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DAPP_DISTRIBUTION=Snap
+      cmake --build build -j"$(nproc)"
+      DESTDIR="$SNAPCRAFT_PART_INSTALL" cmake --install build
     build-packages:
-      - make
       - build-essential
+      - cmake
+      - ninja-build
       - qt6-base-dev
       - qt6-base-private-dev
       - qt6-tools-dev
       - qt6-tools-dev-tools
-      - qmake6
       - pkg-config
       - qt6-5compat-dev
       - libxkbcommon-dev


### PR DESCRIPTION
## Summary
- replace the obsolete qmake build step with the upstream v0.14 CMake/Ninja build
- add the matching CMake/Ninja build dependencies and drop qmake-specific ones
- keep the install staged under `$SNAPCRAFT_PART_INSTALL` via `cmake --install`

## Validation
- reproduced the Launchpad failure locally with `snapcraft --use-lxd --verbose`
- reran `snapcraft --use-lxd --verbose` after the patch and produced `notepadnext_v0.14_amd64.snap` successfully
- confirmed this fixes the specific `src/NotepadNext.pro` missing-file failure seen in Launchpad

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the v0.14 Snapcraft build to upstream CMake/Ninja to fix the Launchpad failure and produce a working snap. Replaces the obsolete qmake flow and stages install via CMake.

- **Bug Fixes**
  - Move build to CMake/Ninja with `-DAPP_DISTRIBUTION=Snap`; stage via `cmake --install` to the part install dir.
  - Resolves the missing `src/NotepadNext.pro` error; confirmed with local `snapcraft --use-lxd` build.

- **Dependencies**
  - Add `cmake`, `ninja-build`; remove `make`, `qmake6`.

<sup>Written for commit c0b30a2e99eea3554515b75b8f0052f16fbe1641. Summary will update on new commits. <a href="https://cubic.dev/pr/popey/notepadnext-snap/pull/7?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

